### PR TITLE
case-insensitive No reply

### DIFF
--- a/main/methods.js
+++ b/main/methods.js
@@ -74,7 +74,8 @@ export const saveMood = async (id, level, comment) => {
   await create({
     'Member': [id],
     'Level': parseInt(level, 10),
-    'Comment': comment === 'no' ? '' : comment,
+    // treat "no" and "No" as empty comments, trimming whitespace
+    'Comment': /^\s*no+\s*$/i.test(comment) ? '' : comment,
     'Date': Date.now()
   })
 }


### PR DESCRIPTION
The Slack app auto-capitalizes replies so people have a tendency to type `No` rather than `no`. This makes it case-insensitive, and adds some tolerance for whitespace

*Pro feature: support for an unlimited number of `o` in your `noooo`* 😉 